### PR TITLE
Change 2 instances of 'boolean' to 'Boolean'

### DIFF
--- a/Doc/c-api/bool.rst
+++ b/Doc/c-api/bool.rst
@@ -6,8 +6,8 @@ Boolean Objects
 ---------------
 
 Booleans in Python are implemented as a subclass of integers.  There are only
-two booleans, :const:`Py_False` and :const:`Py_True`.  As such, the normal
-creation and deletion functions don't apply to booleans.  The following macros
+two Booleans, :const:`Py_False` and :const:`Py_True`.  As such, the normal
+creation and deletion functions don't apply to Booleans.  The following macros
 are available, however.
 
 


### PR DESCRIPTION
Update 'boolean' capitalization. 'Boolean' is a proper noun, and as such should be capitalized. 
Changed 2 instances.